### PR TITLE
Update starter template to match docs

### DIFF
--- a/.evidence/database.config.json
+++ b/.evidence/database.config.json
@@ -1,5 +1,5 @@
 {
-	"keyFilename": "./.evidence/XXXXXXXXXX.json",
-	"projectId": "XXXXXXXXX",
+	"keyFilename": "./.evidence/YOUR-JSON-KEY.json",
+	"projectId": "YOUR-PROJECT-ID",
 	"location": "US"
 }


### PR DESCRIPTION
Updated `.evidence/database.config.json` to match docs: replaced `XXXXXXXXX` with `YOUR-JSON-KEY` and `YOUR-PROJECT-ID` for `keyFilename` and `projectId` respectively

Fixes #1
Refs evidence-dev/evidence#170