### PR TITLE
Automatically open tab on "npm run dev"

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "scripts": {
     "build": "evidence build",
-    "dev": "evidence dev",
+    "dev": "evidence dev -o",
     "test": "evidence build"
   },
   "engines": {


### PR DESCRIPTION
See [this PR](https://github.com/evidence-dev/evidence/pull/289) for details on why we are making this change here.

## Aims:

Comparable products often **Automatically launch a browser tab when the dev server is started**
This is useful behaviour, especially for users who do not have much experience running local servers.

## Implementation:

Adding the `-o` flag to the template project's package.json allows users to turn off this behaviour easily, if they wish