### PR TITLE
get users back into tutorial flow

### DIFF
--- a/pages/index.md
+++ b/pages/index.md
@@ -5,9 +5,10 @@ This is the home page for your project. Navigate to this page by clicking the Ev
 
 You can edit the content of this page by opening **`pages/index.md`** in an editor.
 
-# Steps to get started
-## [1. Connect your database &rarr;](/settings)
-## [2. Start building with Evidence &rarr;](/getting-started)
+# Options to get started
+
+## [1. Try Evidence with demo data &rarr;](https://docs.evidence.dev/tutorial/introduction)
+## [2. Connect your own database &rarr;](/settings)
 
 # Resources
 ## [Star our GitHub repo &rarr;](https://github.com/evidence-dev/evidence)


### PR DESCRIPTION
Multiple demos showed that users doing the tutorial got confused at this stage, if they didn't have a database to connect to.
This brings the tutorial flow back to the top option and should stop users exiting accidentally