### PR TITLE
change double to single quotes

### DIFF
--- a/pages/examples.md
+++ b/pages/examples.md
@@ -1,81 +1,81 @@
 ```intro
-    select "2009-12-31" as year, "Canada" as country, 10000000 as sales_usd
+    select '2009-12-31' as year, 'Canada' as country, 10000000 as sales_usd
     union all
-    select "2010-12-31" as year, "Canada" as country, 13500000 as sales_usd
+    select '2010-12-31' as year, 'Canada' as country, 13500000 as sales_usd
     union all
-    select "2011-12-31" as year, "Canada" as country, 16800000 as sales_usd
+    select '2011-12-31' as year, 'Canada' as country, 16800000 as sales_usd
     union all
-    select "2012-12-31" as year, "Canada" as country, 18900000 as sales_usd
+    select '2012-12-31' as year, 'Canada' as country, 18900000 as sales_usd
     union all
-    select "2013-12-31" as year, "Canada" as country, 24000000 as sales_usd
+    select '2013-12-31' as year, 'Canada' as country, 24000000 as sales_usd
     union all
-    select "2014-12-31" as year, "Canada" as country, 28200000 as sales_usd
+    select '2014-12-31' as year, 'Canada' as country, 28200000 as sales_usd
     union all
-    select "2015-12-31" as year, "Canada" as country, 29400000 as sales_usd
+    select '2015-12-31' as year, 'Canada' as country, 29400000 as sales_usd
     union all
-    select "2016-12-31" as year, "Canada" as country, 18800000 as sales_usd
+    select '2016-12-31' as year, 'Canada' as country, 18800000 as sales_usd
     union all
-    select "2017-12-31" as year, "Canada" as country, 20100000 as sales_usd
+    select '2017-12-31' as year, 'Canada' as country, 20100000 as sales_usd
     union all
-    select "2018-12-31" as year, "Canada" as country, 24400000 as sales_usd
+    select '2018-12-31' as year, 'Canada' as country, 24400000 as sales_usd
     union all
-    select "2019-12-31" as year, "Canada" as country, 26800000 as sales_usd
+    select '2019-12-31' as year, 'Canada' as country, 26800000 as sales_usd
     union all
-    select "2020-12-31" as year, "Canada" as country, 37600000 as sales_usd
+    select '2020-12-31' as year, 'Canada' as country, 37600000 as sales_usd
     union all
-    select "2021-12-31" as year, "Canada" as country, 43400000 as sales_usd
+    select '2021-12-31' as year, 'Canada' as country, 43400000 as sales_usd
     union all
-    select "2009-12-31" as year, "US" as country, 11400000 as sales_usd
+    select '2009-12-31' as year, 'US' as country, 11400000 as sales_usd
     union all
-    select "2010-12-31" as year, "US" as country, 15200000 as sales_usd
+    select '2010-12-31' as year, 'US' as country, 15200000 as sales_usd
     union all
-    select "2011-12-31" as year, "US" as country, 18800000 as sales_usd
+    select '2011-12-31' as year, 'US' as country, 18800000 as sales_usd
     union all
-    select "2012-12-31" as year, "US" as country, 21600000 as sales_usd
+    select '2012-12-31' as year, 'US' as country, 21600000 as sales_usd
     union all
-    select "2013-12-31" as year, "US" as country, 22500000 as sales_usd
+    select '2013-12-31' as year, 'US' as country, 22500000 as sales_usd
     union all
-    select "2014-12-31" as year, "US" as country, 23200000 as sales_usd
+    select '2014-12-31' as year, 'US' as country, 23200000 as sales_usd
     union all
-    select "2015-12-31" as year, "US" as country, 25100000 as sales_usd
+    select '2015-12-31' as year, 'US' as country, 25100000 as sales_usd
     union all
-    select "2016-12-31" as year, "US" as country, 28000000 as sales_usd
+    select '2016-12-31' as year, 'US' as country, 28000000 as sales_usd
     union all
-    select "2017-12-31" as year, "US" as country, 33800000 as sales_usd
+    select '2017-12-31' as year, 'US' as country, 33800000 as sales_usd
     union all
-    select "2018-12-31" as year, "US" as country, 34800000 as sales_usd
+    select '2018-12-31' as year, 'US' as country, 34800000 as sales_usd
     union all
-    select "2019-12-31" as year, "US" as country, 37700000 as sales_usd
+    select '2019-12-31' as year, 'US' as country, 37700000 as sales_usd
     union all
-    select "2020-12-31" as year, "US" as country, 39000000 as sales_usd
+    select '2020-12-31' as year, 'US' as country, 39000000 as sales_usd
     union all
-    select "2021-12-31" as year, "US" as country, 40100000 as sales_usd
+    select '2021-12-31' as year, 'US' as country, 40100000 as sales_usd
     union all
-    select "2009-12-31" as year, "UK" as country, 11100000 as sales_usd
+    select '2009-12-31' as year, 'UK' as country, 11100000 as sales_usd
     union all
-    select "2010-12-31" as year, "UK" as country, 10600000 as sales_usd
+    select '2010-12-31' as year, 'UK' as country, 10600000 as sales_usd
     union all
-    select "2011-12-31" as year, "UK" as country, 10400000 as sales_usd
+    select '2011-12-31' as year, 'UK' as country, 10400000 as sales_usd
     union all
-    select "2012-12-31" as year, "UK" as country, 10100000 as sales_usd
+    select '2012-12-31' as year, 'UK' as country, 10100000 as sales_usd
     union all
-    select "2013-12-31" as year, "UK" as country, 10800000 as sales_usd
+    select '2013-12-31' as year, 'UK' as country, 10800000 as sales_usd
     union all
-    select "2014-12-31" as year, "UK" as country, 12000000 as sales_usd
+    select '2014-12-31' as year, 'UK' as country, 12000000 as sales_usd
     union all
-    select "2015-12-31" as year, "UK" as country, 14100000 as sales_usd
+    select '2015-12-31' as year, 'UK' as country, 14100000 as sales_usd
     union all
-    select "2016-12-31" as year, "UK" as country, 15800000 as sales_usd
+    select '2016-12-31' as year, 'UK' as country, 15800000 as sales_usd
     union all
-    select "2017-12-31" as year, "UK" as country, 19400000 as sales_usd
+    select '2017-12-31' as year, 'UK' as country, 19400000 as sales_usd
     union all
-    select "2018-12-31" as year, "UK" as country, 21100000 as sales_usd
+    select '2018-12-31' as year, 'UK' as country, 21100000 as sales_usd
     union all
-    select "2019-12-31" as year, "UK" as country, 23400000 as sales_usd
+    select '2019-12-31' as year, 'UK' as country, 23400000 as sales_usd
     union all
-    select "2020-12-31" as year, "UK" as country, 25800000 as sales_usd
+    select '2020-12-31' as year, 'UK' as country, 25800000 as sales_usd
     union all
-    select "2021-12-31" as year, "UK" as country, 28800000 as sales_usd
+    select '2021-12-31' as year, 'UK' as country, 28800000 as sales_usd
 ```
 
 # Charts
@@ -86,9 +86,9 @@
     x=year
     y=sales_usd
     series=country
-    title="Sales by Country"
-    subtitle="$ in USD"
-    yAxisTitle="annual sales"
+    title='Sales by Country'
+    subtitle='$ in USD'
+    yAxisTitle='annual sales'
 />
 
 ## Area Chart
@@ -119,19 +119,19 @@
 ## Horizontal Bar Chart
 
 ```simple_bar
-select "North" as country, -105 as value
+select 'North' as country, -105 as value
 union all
-select "Northwest" as country, 101 as value
+select 'Northwest' as country, 101 as value
 union all
-select "South" as country, 113 as value
+select 'South' as country, 113 as value
 union all
-select "Southeast" as country, -78 as value
+select 'Southeast' as country, -78 as value
 union all
-select "East" as country, 112 as value
+select 'East' as country, 112 as value
 union all
-select "West" as country, 103 as value
+select 'West' as country, 103 as value
 union all
-select "Southwest" as country, 110 as value
+select 'Southwest' as country, 110 as value
 ```
 
 <BarChart
@@ -141,8 +141,8 @@ select "Southwest" as country, 110 as value
     xAxisTitle=Country 
     yAxisTitle=Value 
     swapXY=true 
-    title="Year-to-Date Value by Region" 
-    subtitle="South region leading as of June 30/21"
+    title='Year-to-Date Value by Region' 
+    subtitle='South region leading as of June 30/21'
 />
 
 ## Scatter Plot
@@ -375,7 +375,7 @@ Check out the [Evidence Docs](https://docs.evidence.dev/features/charts/examples
 ```us_sales
 select *
 from ${intro} 
-where country = "US"
+where country = 'US'
 order by year desc
 ```
 

--- a/pages/getting-started/index.md
+++ b/pages/getting-started/index.md
@@ -11,11 +11,11 @@ When you are in development mode (running your project locally), queries are sho
 In either case, you (or your audience) can hide or show queries using the button up to the right.
 
 ```simple_query
-select "orange" as name, 100 as number
+select 'orange' as name, 100 as number
 union all
-select "banana" as name, 200 as number
+select 'banana' as name, 200 as number
 union all
-select "apple" as name, 300 as number
+select 'apple' as name, 300 as number
 ```
 
 ## Including Data in Text
@@ -31,7 +31,7 @@ For example, we can query the results of the simple query from above:
 
 ```subquery
 select * from ${simple_query}
-where name = "apple"
+where name = 'apple'
 ```
 
 ## [See how to use the data from your queries &rarr;](/getting-started/using-query-results)

--- a/pages/getting-started/using-query-results.md
+++ b/pages/getting-started/using-query-results.md
@@ -3,83 +3,83 @@
 ## Charts
 
 ```intro
-    select "2009-12-31" as year, "Canada" as country, 10000000 as sales_usd
+    select '2009-12-31' as year, 'Canada' as country, 10000000 as sales_usd
     union all
-    select "2010-12-31" as year, "Canada" as country, 13500000 as sales_usd
+    select '2010-12-31' as year, 'Canada' as country, 13500000 as sales_usd
     union all
-    select "2011-12-31" as year, "Canada" as country, 16800000 as sales_usd
+    select '2011-12-31' as year, 'Canada' as country, 16800000 as sales_usd
     union all
-    select "2012-12-31" as year, "Canada" as country, 18900000 as sales_usd
+    select '2012-12-31' as year, 'Canada' as country, 18900000 as sales_usd
     union all
-    select "2013-12-31" as year, "Canada" as country, 24000000 as sales_usd
+    select '2013-12-31' as year, 'Canada' as country, 24000000 as sales_usd
     union all
-    select "2014-12-31" as year, "Canada" as country, 28200000 as sales_usd
+    select '2014-12-31' as year, 'Canada' as country, 28200000 as sales_usd
     union all
-    select "2015-12-31" as year, "Canada" as country, 29400000 as sales_usd
+    select '2015-12-31' as year, 'Canada' as country, 29400000 as sales_usd
     union all
-    select "2016-12-31" as year, "Canada" as country, 18800000 as sales_usd
+    select '2016-12-31' as year, 'Canada' as country, 18800000 as sales_usd
     union all
-    select "2017-12-31" as year, "Canada" as country, 20100000 as sales_usd
+    select '2017-12-31' as year, 'Canada' as country, 20100000 as sales_usd
     union all
-    select "2018-12-31" as year, "Canada" as country, 24400000 as sales_usd
+    select '2018-12-31' as year, 'Canada' as country, 24400000 as sales_usd
     union all
-    select "2019-12-31" as year, "Canada" as country, 26800000 as sales_usd
+    select '2019-12-31' as year, 'Canada' as country, 26800000 as sales_usd
     union all
-    select "2020-12-31" as year, "Canada" as country, 37600000 as sales_usd
+    select '2020-12-31' as year, 'Canada' as country, 37600000 as sales_usd
     union all
-    select "2021-12-31" as year, "Canada" as country, 43400000 as sales_usd
+    select '2021-12-31' as year, 'Canada' as country, 43400000 as sales_usd
     union all
-    select "2009-12-31" as year, "US" as country, 11400000 as sales_usd
+    select '2009-12-31' as year, 'US' as country, 11400000 as sales_usd
     union all
-    select "2010-12-31" as year, "US" as country, 15200000 as sales_usd
+    select '2010-12-31' as year, 'US' as country, 15200000 as sales_usd
     union all
-    select "2011-12-31" as year, "US" as country, 18800000 as sales_usd
+    select '2011-12-31' as year, 'US' as country, 18800000 as sales_usd
     union all
-    select "2012-12-31" as year, "US" as country, 21600000 as sales_usd
+    select '2012-12-31' as year, 'US' as country, 21600000 as sales_usd
     union all
-    select "2013-12-31" as year, "US" as country, 22500000 as sales_usd
+    select '2013-12-31' as year, 'US' as country, 22500000 as sales_usd
     union all
-    select "2014-12-31" as year, "US" as country, 23200000 as sales_usd
+    select '2014-12-31' as year, 'US' as country, 23200000 as sales_usd
     union all
-    select "2015-12-31" as year, "US" as country, 25100000 as sales_usd
+    select '2015-12-31' as year, 'US' as country, 25100000 as sales_usd
     union all
-    select "2016-12-31" as year, "US" as country, 28000000 as sales_usd
+    select '2016-12-31' as year, 'US' as country, 28000000 as sales_usd
     union all
-    select "2017-12-31" as year, "US" as country, 33800000 as sales_usd
+    select '2017-12-31' as year, 'US' as country, 33800000 as sales_usd
     union all
-    select "2018-12-31" as year, "US" as country, 34800000 as sales_usd
+    select '2018-12-31' as year, 'US' as country, 34800000 as sales_usd
     union all
-    select "2019-12-31" as year, "US" as country, 37700000 as sales_usd
+    select '2019-12-31' as year, 'US' as country, 37700000 as sales_usd
     union all
-    select "2020-12-31" as year, "US" as country, 39000000 as sales_usd
+    select '2020-12-31' as year, 'US' as country, 39000000 as sales_usd
     union all
-    select "2021-12-31" as year, "US" as country, 40100000 as sales_usd
+    select '2021-12-31' as year, 'US' as country, 40100000 as sales_usd
     union all
-    select "2009-12-31" as year, "UK" as country, 11100000 as sales_usd
+    select '2009-12-31' as year, 'UK' as country, 11100000 as sales_usd
     union all
-    select "2010-12-31" as year, "UK" as country, 10600000 as sales_usd
+    select '2010-12-31' as year, 'UK' as country, 10600000 as sales_usd
     union all
-    select "2011-12-31" as year, "UK" as country, 10400000 as sales_usd
+    select '2011-12-31' as year, 'UK' as country, 10400000 as sales_usd
     union all
-    select "2012-12-31" as year, "UK" as country, 10100000 as sales_usd
+    select '2012-12-31' as year, 'UK' as country, 10100000 as sales_usd
     union all
-    select "2013-12-31" as year, "UK" as country, 10800000 as sales_usd
+    select '2013-12-31' as year, 'UK' as country, 10800000 as sales_usd
     union all
-    select "2014-12-31" as year, "UK" as country, 12000000 as sales_usd
+    select '2014-12-31' as year, 'UK' as country, 12000000 as sales_usd
     union all
-    select "2015-12-31" as year, "UK" as country, 14100000 as sales_usd
+    select '2015-12-31' as year, 'UK' as country, 14100000 as sales_usd
     union all
-    select "2016-12-31" as year, "UK" as country, 15800000 as sales_usd
+    select '2016-12-31' as year, 'UK' as country, 15800000 as sales_usd
     union all
-    select "2017-12-31" as year, "UK" as country, 19400000 as sales_usd
+    select '2017-12-31' as year, 'UK' as country, 19400000 as sales_usd
     union all
-    select "2018-12-31" as year, "UK" as country, 21100000 as sales_usd
+    select '2018-12-31' as year, 'UK' as country, 21100000 as sales_usd
     union all
-    select "2019-12-31" as year, "UK" as country, 23400000 as sales_usd
+    select '2019-12-31' as year, 'UK' as country, 23400000 as sales_usd
     union all
-    select "2020-12-31" as year, "UK" as country, 25800000 as sales_usd
+    select '2020-12-31' as year, 'UK' as country, 25800000 as sales_usd
     union all
-    select "2021-12-31" as year, "UK" as country, 28800000 as sales_usd
+    select '2021-12-31' as year, 'UK' as country, 28800000 as sales_usd
 ```
 
 <LineChart
@@ -87,8 +87,8 @@
     x=year
     y=sales_usd
     series=country
-    title="Sales by Country"
-    subtitle="$ in USD"
+    title='Sales by Country'
+    subtitle='$ in USD'
 />
 
 <BarChart
@@ -96,8 +96,8 @@
     x=year
     y=sales_usd
     series=country
-    title="Sales by Country"
-    subtitle="$ in USD"
+    title='Sales by Country'
+    subtitle='$ in USD'
 />
 
 
@@ -112,7 +112,7 @@
 ```us_sales
 select *
 from ${intro} 
-where country = "US"
+where country = 'US'
 order by year desc
 ```
 


### PR DESCRIPTION
It looks like Snowflake and other databases doesn't accept double quotes around strings (") and instead uses single quotes ('). Our example queries are using double quotes.