### PR TITLE
Auto connect template to included duckDB

### DIFF
--- a/.evidence/template/evidence.settings.json
+++ b/.evidence/template/evidence.settings.json
@@ -1,0 +1,1 @@
+{"database":"duckdb","credentials":{"filename":"needful_things.duckdb","gitignoreDuckdb":null}}


### PR DESCRIPTION
Fixes evidence-dev/evidence#804

Forces the default settings into `evidence.settings.json`.