### PR TITLE
Remove .github from post clone removal via degit

### DIFF
--- a/degit.json
+++ b/degit.json
@@ -1,7 +1,7 @@
 [
 	{
 		"action": "remove",
-		"files": [".github", ".devcontainer"]
+		"files": [".devcontainer"]
 	},
     {
         "action": "clone",


### PR DESCRIPTION
Already removed the github workflows
This will get rid of the warning message when cloning via degit