### PR TITLE
Instructions on connecting to duckdb manually

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,15 @@ See [the CLI docs](https://docs.evidence.dev/cli/) for more command information.
 
 **Note:** Codespaces is much faster on the Desktop app. After the Codespace has booted, select the hamburger menu → Open in VS Code Desktop.
 
+## Connection Issues
+
+If you see `✗ orders_by_month Missing database credentials`, you need to add the connection to the demo database:
+
+1. Open the settings menu at [localhost:3000/settings](http://localhost:3000/settings)
+2. select `DuckDB`
+3. enter `needful_things`
+4. select `.duckdb` and save
+
 ## Learning More
 
 - [Docs](https://docs.evidence.dev/)


### PR DESCRIPTION
If you create your evidence project by cloning this template rather than using degit:
`git clone https://github.com/evidence-dev/template`

Then you will get 

`✗ orders_by_month Missing database credentials`

This is because no credentials have been configured. During `degit` we auto create a credentials file for you, but this is not possible if someone runs `git clone`

This PR adds instructions for manually configuring a connection