### PR TITLE
Auto-open README.md in Codespaces

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -22,6 +22,7 @@
       },
       "codespaces": {
         "openFiles": [
+           "README.md",
            "pages/index.md"
         ]
       }


### PR DESCRIPTION
This proposal adds "README.md" to the list of files to open when Codespaces launches.

This is helpful because on first run in the Codespace, the Evidence extension has not yet loaded, which means it probably won't get rendered in the "Getting Started" section of the Welcome page. By adding this to auto-open, users find out about the "Start Evidence" button even if the extension getting started section does not display.