### PR TITLE
fix: delete .github/workflows in degit

### DIFF
--- a/degit.json
+++ b/degit.json
@@ -1,6 +1,9 @@
 [
 	{
 		"action": "remove",
-		"files": [".devcontainer"]
+		"files": [
+			".devcontainer",
+			".github"
+		]
 	}
 ]


### PR DESCRIPTION
Before this change, when a user clones the template using `degit`, they will get our `.github/workflows` folder, which is useless and confusing to them.

![before](https://github.com/user-attachments/assets/9fa702ce-7e8d-44f2-bd75-0fec891fe894)

After this change, the `.github` folder is deleted

![after](https://github.com/user-attachments/assets/436f2bd2-ad5e-4cb8-95fc-3aa3345fa09c)

